### PR TITLE
Implement HF advice service

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.32.1
 sqlalchemy==2.0.36
 pydantic==2.10.3
 docker==7.1.0
+huggingface_hub==0.23.2

--- a/backend/services/advice_service.py
+++ b/backend/services/advice_service.py
@@ -1,0 +1,76 @@
+# AIアドバイス生成サービス
+from huggingface_hub import InferenceClient
+import os
+
+# Hugging Face InferenceClient を初期化
+client = InferenceClient(
+    provider="huggingface",
+    token=os.getenv("HUGGINGFACE_API_KEY"),
+)
+
+# 使用するモデル名
+HUGGINGFACE_MODEL_ID = "Qwen/Qwen2.5-32B-Instruct"
+
+
+async def generate_advice_with_huggingface(
+    problem_title: str,
+    problem_description: str,
+    user_code: str,
+    execution_stdout: str | None,
+    execution_stderr: str | None,
+    correct_code: str | None = None,
+) -> str:
+    """指定された情報を基にHugging Faceのモデルからアドバイスを生成する"""
+
+    prompt_string = f"""
+あなたは、Pythonプログラミングを学ぶ初学者をサポートする親切なAIアシスタントです。
+以下の情報に基づいて、学習者が自分で間違いに気づき、解決できるようになるためのヒントやアドバイスを生成してください。
+
+【重要】
+- **絶対にコードの正解そのものを直接教えてはいけません。**
+- 指摘は具体的かつ建設的に行い、学習者のモチベーションを維持するよう努めてください。
+- 難しい専門用語は避け、分かりやすい言葉で説明してください。
+- アドバイスは日本語でお願いします。
+
+【課題情報】
+タイトル: {problem_title}
+問題文:
+{problem_description}
+
+【学習者の提出コード】
+```python
+{user_code}
+```
+
+【コードの実行結果】
+標準出力:
+{execution_stdout if execution_stdout else "なし"}
+標準エラー:
+{execution_stderr if execution_stderr else "なし"}
+
+【アドバイスのポイント】
+1.  **エラーがある場合:**
+    - エラーメッセージ ({execution_stderr}) が何を意味するのか、考えられる原因は何かを優しく説明してください。
+    - エラーが発生している箇所を特定するためのデバッグ方法（例: print文の挿入箇所など）を提案してください。
+2.  **エラーがないが期待通りに動作しない場合 (または改善点がある場合):**
+    - コードのロジックで改善できる点や、より効率的な書き方があれば示唆してください。
+    - 変数名やコメントの付け方など、読みやすいコードにするための一般的なアドバイスも適宜含めてください。
+    - (もし `correct_code` が提供されていれば、それを直接見せるのではなく、学習者のコードとの違いからヒントを得られるような問いかけをしてください)
+3.  **よくある間違いの指摘:**
+    - 初学者が陥りやすい間違いのパターンに合致する場合は、それとなく教えてあげてください。
+      (例: for文の範囲、インデックスエラー、無限ループの可能性など)
+
+上記を踏まえて、学習者へのアドバイスを生成してください。
+"""
+
+    try:
+        completion = client.chat.completions.create(
+            model=HUGGINGFACE_MODEL_ID,
+            messages=[{"role": "user", "content": prompt_string}],
+            max_tokens=1500,
+        )
+        advice_text = completion.choices[0].message.content
+        return advice_text
+    except Exception as e:
+        print(f"Hugging Face API呼び出し中にエラーが発生しました: {e}")
+        return "申し訳ありません。アドバイスの生成中にエラーが発生しました。"


### PR DESCRIPTION
## Summary
- add HuggingFace-based advice service
- generate advice when code is submitted
- include advice text in saved submissions and API response
- add huggingface_hub to backend requirements

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services', boto3 missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684031869d8083278f403c3ebba8a29f