### PR TITLE
Add admin problem management pages

### DIFF
--- a/frontend/src/app/admin/problems/[id]/edit/page.tsx
+++ b/frontend/src/app/admin/problems/[id]/edit/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import CodeEditor from "@/components/CodeEditor";
+import { fetchProblem, updateProblem, ApiError } from "@/lib/api";
+import { ProblemCreate } from "@/types/api";
+
+export default function EditProblemPage() {
+  const params = useParams();
+  const id = Number(params.id);
+  const router = useRouter();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [correctCode, setCorrectCode] = useState("");
+  const [testInput, setTestInput] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setError(null);
+        const data = await fetchProblem(String(id));
+        setTitle(data.title);
+        setDescription(data.description);
+        setCorrectCode(data.correct_code);
+        setTestInput(data.test_input || "");
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError("読み込みに失敗しました");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) {
+      load();
+    }
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !description.trim() || !correctCode.trim()) {
+      setError("必須項目を入力してください");
+      return;
+    }
+    const payload: ProblemCreate = {
+      id,
+      title,
+      description,
+      correct_code: correctCode,
+      test_input: testInput || null,
+    };
+    try {
+      setSubmitting(true);
+      await updateProblem(id, payload);
+      router.push("/admin/problems");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("更新に失敗しました");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-4">読み込み中...</div>;
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl p-4">
+      <h1 className="text-2xl font-bold mb-4">課題編集</h1>
+      {error && <div className="mb-4 text-red-600">{error}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-medium mb-1">タイトル</label>
+          <input
+            type="text"
+            className="w-full border rounded p-2"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">問題文</label>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={6}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">正解コード</label>
+          <CodeEditor value={correctCode} onChange={setCorrectCode} language="python" height="200px" />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">テストケース入力 (省略可)</label>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={2}
+            value={testInput}
+            onChange={(e) => setTestInput(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          {submitting ? "更新中..." : "更新"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/problems/new/page.tsx
+++ b/frontend/src/app/admin/problems/new/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import CodeEditor from "@/components/CodeEditor";
+import { createProblem, ApiError } from "@/lib/api";
+import { ProblemCreate } from "@/types/api";
+
+export default function NewProblemPage() {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [correctCode, setCorrectCode] = useState("");
+  const [testInput, setTestInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !description.trim() || !correctCode.trim()) {
+      setError("必須項目を入力してください");
+      return;
+    }
+    const payload: ProblemCreate = {
+      title,
+      description,
+      correct_code: correctCode,
+      test_input: testInput || null,
+    };
+    try {
+      setSubmitting(true);
+      await createProblem(payload);
+      router.push("/admin/problems");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("登録に失敗しました");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl p-4">
+      <h1 className="text-2xl font-bold mb-4">新規課題作成</h1>
+      {error && <div className="mb-4 text-red-600">{error}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-medium mb-1">タイトル</label>
+          <input
+            type="text"
+            className="w-full border rounded p-2"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">問題文</label>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={6}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">正解コード</label>
+          <CodeEditor value={correctCode} onChange={setCorrectCode} language="python" height="200px" />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">テストケース入力 (省略可)</label>
+          <textarea
+            className="w-full border rounded p-2"
+            rows={2}
+            value={testInput}
+            onChange={(e) => setTestInput(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          {submitting ? "登録中..." : "登録"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/problems/page.tsx
+++ b/frontend/src/app/admin/problems/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { fetchProblems, deleteProblem, ApiError } from "@/lib/api";
+import { Problem } from "@/types/api";
+
+export default function AdminProblemsPage() {
+  const [problems, setProblems] = useState<Problem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const router = useRouter();
+
+  const loadProblems = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchProblems();
+      setProblems(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("問題の取得に失敗しました");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadProblems();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm("本当に削除しますか？")) return;
+    try {
+      setDeletingId(id);
+      await deleteProblem(id);
+      await loadProblems();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        alert(err.message);
+      } else {
+        alert("削除に失敗しました");
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">課題一覧</h1>
+        <Link
+          href="/admin/problems/new"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          新規課題作成
+        </Link>
+      </div>
+
+      {error && (
+        <div className="mb-4 text-red-600">{error}</div>
+      )}
+
+      {loading ? (
+        <div>読み込み中...</div>
+      ) : (
+        <table className="min-w-full bg-white border">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2 w-12">ID</th>
+              <th className="border px-4 py-2">タイトル</th>
+              <th className="border px-4 py-2 w-32">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {problems.map((p) => (
+              <tr key={p.id}>
+                <td className="border px-4 py-2 text-center">{p.id}</td>
+                <td className="border px-4 py-2">{p.title}</td>
+                <td className="border px-4 py-2 text-center space-x-2">
+                  <Link
+                    href={`/admin/problems/${p.id}/edit`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    編集
+                  </Link>
+                  <button
+                    onClick={() => handleDelete(p.id)}
+                    disabled={deletingId === p.id}
+                    className="text-red-600 hover:underline"
+                  >
+                    {deletingId === p.id ? "削除中" : "削除"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { Problem, SubmissionCreate, SubmissionResponse } from "@/types/api";
+import { Problem, ProblemCreate, SubmissionCreate, SubmissionResponse } from "@/types/api";
 
 // サーバーサイドとクライアントサイドで異なるAPI URLを使用
 const getApiBaseUrl = () => {
@@ -110,6 +110,72 @@ export async function fetchProblems(): Promise<Problem[]> {
         }
         if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
             throw new ApiError(500, `ネットワークエラー: APIサーバーに接続できません (${apiUrl})`);
+        }
+        throw new ApiError(500, `ネットワークエラー: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+// 新しい問題を作成
+export async function createProblem(problem: ProblemCreate): Promise<Problem> {
+    const apiUrl = getApiBaseUrl();
+    try {
+        const response = await fetch(`${apiUrl}/problems/`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(problem),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new ApiError(response.status, `問題の作成に失敗しました: ${errorText}`);
+        }
+        return response.json();
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error;
+        }
+        throw new ApiError(500, `ネットワークエラー: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+// 既存の問題を更新
+export async function updateProblem(id: number, problem: ProblemCreate): Promise<Problem> {
+    const apiUrl = getApiBaseUrl();
+    try {
+        const response = await fetch(`${apiUrl}/problems/${id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(problem),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new ApiError(response.status, `問題の更新に失敗しました: ${errorText}`);
+        }
+        return response.json();
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error;
+        }
+        throw new ApiError(500, `ネットワークエラー: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+// 問題を削除
+export async function deleteProblem(id: number): Promise<void> {
+    const apiUrl = getApiBaseUrl();
+    try {
+        const response = await fetch(`${apiUrl}/problems/${id}`, {
+            method: "DELETE",
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new ApiError(response.status, `問題の削除に失敗しました: ${errorText}`);
+        }
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error;
         }
         throw new ApiError(500, `ネットワークエラー: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -10,6 +10,15 @@ export interface Problem {
     updated_at: string;
 }
 
+// 新規作成・更新時に使用する型
+export interface ProblemCreate {
+    id?: number;
+    title: string;
+    description: string;
+    correct_code: string;
+    test_input?: string | null;
+}
+
 export interface SubmissionCreate {
     problem_id: number;
     user_code: string;


### PR DESCRIPTION
## Summary
- add type `ProblemCreate`
- extend API client with create/update/delete helpers
- implement admin problem list with edit/delete
- add new problem form
- add edit problem form

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684189b663d08327b68ee76ea0ecd038