### PR TITLE
Add markdown rendering in advice components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
     "@monaco-editor/react": "^4.5.2",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-markdown": "^9.0.6",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/admin/problems/page.tsx
+++ b/frontend/src/app/admin/problems/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { fetchProblems, deleteProblem, ApiError } from "@/lib/api";
 import { Problem } from "@/types/api";
 
@@ -12,7 +11,6 @@ export default function AdminProblemsPage() {
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
-  const router = useRouter();
 
   const loadProblems = async () => {
     try {

--- a/frontend/src/components/AdviceDisplay.tsx
+++ b/frontend/src/components/AdviceDisplay.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const markdownPlugins: any[] = [remarkGfm];
 import { SubmissionResponse } from '@/types/api';
 
 interface AdviceDisplayProps {
@@ -96,9 +101,12 @@ const AdviceDisplay: React.FC<AdviceDisplayProps> = ({ executionResult, isLoadin
       {executionResult.advice_text && (
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
           <h3 className="text-lg font-semibold text-blue-900 mb-3">AIアドバイス</h3>
-          <div className="text-blue-800 whitespace-pre-wrap">
+          <ReactMarkdown
+            className="prose max-w-none text-blue-800"
+            remarkPlugins={markdownPlugins}
+          >
             {executionResult.advice_text}
-          </div>
+          </ReactMarkdown>
         </div>
       )}
     </div>

--- a/frontend/src/components/ExecutionResultDisplay.tsx
+++ b/frontend/src/components/ExecutionResultDisplay.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { SubmissionResponse } from '@/types/api';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const markdownPlugins: any[] = [remarkGfm];
 
 interface ExecutionResultDisplayProps {
   executionResult: SubmissionResponse | null;
@@ -186,9 +191,12 @@ const ExecutionResultDisplay: React.FC<ExecutionResultDisplayProps> = ({
             <span className="text-2xl">🤖</span>
             <h3 className="text-lg font-semibold text-blue-900">AIアドバイス</h3>
           </div>
-          <div className="text-blue-800 whitespace-pre-wrap leading-relaxed">
+          <ReactMarkdown
+            className="prose max-w-none text-blue-800"
+            remarkPlugins={markdownPlugins}
+          >
             {executionResult.advice_text}
-          </div>
+          </ReactMarkdown>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add `react-markdown` and `remark-gfm` to frontend dependencies
- render advice text with ReactMarkdown in `AdviceDisplay` and `ExecutionResultDisplay`
- remove unused router variable in admin page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684274212c3483279478e357f0f7aa1d