### PR TITLE
Remove outdated ID check in update_problem

### DIFF
--- a/backend/routers/problems.py
+++ b/backend/routers/problems.py
@@ -86,11 +86,6 @@ async def update_problem(
             status_code=404, detail=f"Problem with ID {problem_id} not found"
         )
 
-    # IDが一致しているか確認
-    if updated_problem.id != problem_id:
-        raise HTTPException(
-            status_code=400, detail="Problem ID in path and body must match"
-        )
 
     # 問題を更新
     db_problem.title = updated_problem.title


### PR DESCRIPTION
## Summary
- drop erroneous `updated_problem.id` check in `update_problem`

## Testing
- `PYTHONPATH=. python3 test/simple_sandbox_test.py` *(fails: Error while fetching server API version)*
- `PYTHONPATH=. python3 test/test_sandbox_complete.py` *(fails: Error while fetching server API version)*
- `python3 test/api_smoke_test.py` *(fails: API did not start in time)*
- `python3 test/test_docker_basic.py` *(fails: Error while fetching server API version)*
- `python3 -m pytest -q backend/test` *(fails: API did not start in time)*

------
https://chatgpt.com/codex/tasks/task_e_68438d1e75988327b76407da8c524b9f